### PR TITLE
Feature/simplify json data structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,6 @@ The coordinates, color, and other metadata of the annotations must be saved in a
         {
           "uid": "some-uid",
           "name": "some-name",
-          "imgCoords": [
-            {
-              "x": 0.0,
-              "y": 0.0
-            },
-            // ...
-          ],
           // http://paperjs.org/reference/path/
           "path": [
             "Path",
@@ -79,24 +72,6 @@ A working example can be found below:
         {
           "uid": "dc466dd0-15f7-11ea-94f7-3541d0425afc",
           "name": "dc466dd0-15f7-11ea-94f7-3541d0425afc",
-          "imgCoords": [
-            {
-              "x": 4445.56952,
-              "y": 2904.39074
-            },
-            {
-              "x": 4444.66043,
-              "y": 2909.84528
-            },
-            {
-              "x": 4445.56952,
-              "y": 2921.66346
-            },
-            {
-              "x": 4448.29679,
-              "y": 2922.57255
-            }
-          ],
           // http://paperjs.org/reference/path/
           "path": [
             "Path",

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSON.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSON.java
@@ -48,7 +48,7 @@ public class ExportAnnotationServiceJSON implements PathCommand{
          * contain the slide name.
          */
         final String slideName = qupath.getViewer().getServer().getDisplayedImageName();
-        fileChooser.setInitialFileName(slideName + "_imported");
+        fileChooser.setInitialFileName(slideName + ".svs.annotations");
         File inputFile = fileChooser.showSaveDialog(null );
 
         if (inputFile == null) {

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSON.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSON.java
@@ -47,7 +47,8 @@ public class ExportAnnotationServiceJSON implements PathCommand{
          * The annotation service code looks for files with the slide's name to import the annotation, so the file must
          * contain the slide name.
          */
-        fileChooser.setInitialFileName(qupath.getViewer().getServer().getDisplayedImageName() + "_imported");
+        final String slideName = qupath.getViewer().getServer().getDisplayedImageName();
+        fileChooser.setInitialFileName(slideName + "_imported");
         File inputFile = fileChooser.showSaveDialog(null );
 
         if (inputFile == null) {
@@ -56,7 +57,7 @@ public class ExportAnnotationServiceJSON implements PathCommand{
         }
 
         PluginRunnerFX runner = new PluginRunnerFX(qupath,false);
-        ExportAnnotationServiceJSONPlugin exportJSON = new ExportAnnotationServiceJSONPlugin(inputFile);
+        ExportAnnotationServiceJSONPlugin exportJSON = new ExportAnnotationServiceJSONPlugin(inputFile, slideName);
         exportJSON.runPlugin(runner, null);
     }
 }

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -203,25 +203,23 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                     pathProperties.addProperty("closed", true);
                     JsonArray fillColour = new JsonArray();
 
-                    if (annotation.getPathClass() == null) {
-                        fillColour.add(1);
-                        fillColour.add(0);
-                        fillColour.add(0);
-                        fillColour.add(0.5);
-                    } else {
-                        int annotationRGB = annotation.getPathClass().getColor();
-                        fillColour.add((double) (ColorTools.red(annotationRGB)) / 255.0);
-                        fillColour.add((double) (ColorTools.green(annotationRGB)) / 255.0);
-                        fillColour.add((double) (ColorTools.blue(annotationRGB)) / 255.0);
-                        fillColour.add(0.5);
-                    }
+                    JsonArray strokeColor = new JsonArray();
+
+                    final int annotationRGB = annotation.getColorRGB();
+                    final double redValue = (double) (ColorTools.red(annotationRGB)) / 255.0;
+                    final double greenValue = (double) (ColorTools.green(annotationRGB)) / 255.0;
+                    final double blueValue = (double) (ColorTools.blue(annotationRGB)) / 255.0;
+                    fillColour.add(redValue);
+                    fillColour.add(greenValue);
+                    fillColour.add(blueValue);
+                    fillColour.add(0.5);
+                    strokeColor.add(redValue);
+                    strokeColor.add(greenValue);
+                    strokeColor.add(blueValue);
+
+                    pathProperties.add("strokeColor", strokeColor);
 
                     pathProperties.add("fillColor", fillColour);
-                    JsonArray strokeColor = new JsonArray();
-                    strokeColor.add(0);
-                    strokeColor.add(0);
-                    strokeColor.add(0);
-                    pathProperties.add("strokeColor", strokeColor);
                     pathProperties.addProperty("strokeScaling", false);
 
                     path.add(pathProperties);

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -205,7 +205,13 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
 
                     JsonArray strokeColor = new JsonArray();
 
-                    final int annotationRGB = annotation.getColorRGB();
+                    /**
+                     * PathObject.color is null by default, thus the color of the annotation needs to be manually set if
+                     * the user used the default color of RGB(255, 0, 0) (i.e. Red)
+                     */
+                    final int annotationRGB = annotation.getColorRGB() != null
+                        ? annotation.getColorRGB()
+                        : 16711680;
                     final double redValue = (double) (ColorTools.red(annotationRGB)) / 255.0;
                     final double greenValue = (double) (ColorTools.green(annotationRGB)) / 255.0;
                     final double blueValue = (double) (ColorTools.blue(annotationRGB)) / 255.0;

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -115,13 +115,6 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
          *         {
          *           "uid": "some-uid",
          *           "name": "some-name",
-         *           "imgCoords": [
-         *             {
-         *               "x": 0.0,
-         *               "y": 0.0
-         *             },
-         *             // ...
-         *           ],
          *           // http://paperjs.org/reference/path/
          *           "path": [
          *             "Path",

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -151,16 +151,10 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                     jsonAnnotation.addProperty("uid", count);
                     jsonAnnotation.addProperty("name", (annotation.getPathClass() == null) ? "Unclassified" : annotation.getPathClass().toString());
 
-                    JsonArray imgCoords = new JsonArray();
                     JsonArray pathCoords = new JsonArray();
 
                     for (Point2 point : annotationPolygons[1][i].getPolygonPoints()) {
-                        JsonObject annotationPoint = new JsonObject();
-                        annotationPoint.addProperty("x", point.getX());
-                        annotationPoint.addProperty("y", point.getY());
-                        imgCoords.add(annotationPoint);
-
-                        //It appears that to convert between the image coordinates and the coordinates used to draw the annotation, we divide the image coordinates
+                         //It appears that to convert between the image coordinates and the coordinates used to draw the annotation, we divide the image coordinates
                         //in both dimensions by the total *width* of the image and then multiply by a factor of 1000.
 
                         JsonObject pathCoordPoint = new JsonObject();
@@ -168,8 +162,6 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                         pathCoordPoint.addProperty("1", point.getY() / imageData.getServer().getWidth() * 1000);
                         pathCoords.add(pathCoordPoint);
                     }
-
-                    jsonAnnotation.add("imgCoords", imgCoords);
 
                     JsonArray path = new JsonArray();
                     path.add("Path");

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -24,9 +24,15 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
 
     private File annotationFile;
     private String lastMessage = "";
+    private String fileName = "";
 
     public ExportAnnotationServiceJSONPlugin( File annotationFile) {
         this.annotationFile = annotationFile;
+    }
+
+    public ExportAnnotationServiceJSONPlugin(File annotationFile, String fileName) {
+        this.annotationFile = annotationFile;
+        this.fileName = fileName;
     }
 
 

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -154,13 +154,26 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                     JsonArray pathCoords = new JsonArray();
 
                     for (Point2 point : annotationPolygons[1][i].getPolygonPoints()) {
-                         //It appears that to convert between the image coordinates and the coordinates used to draw the annotation, we divide the image coordinates
-                        //in both dimensions by the total *width* of the image and then multiply by a factor of 1000.
+                        JsonArray segment = new JsonArray();
+                        JsonArray pathCoordPoint = new JsonArray();
+                        pathCoordPoint.add(point.getX());
+                        pathCoordPoint.add(point.getY());
+                        segment.add(pathCoordPoint);
+                        /**
+                         * In order to mimic the data-structure of a PaperJS.segment, there needs to be two additional
+                         * arrays
+                         *
+                         * Since this data is not used, they can contain zeroed coordinates
+                         *
+                         * http://paperjs.org/reference/segment/#segment
+                         */
+                        JsonArray zeroArray = new JsonArray();
+                        zeroArray.add(0.0);
+                        zeroArray.add(0.0);
+                        segment.add(zeroArray);
+                        segment.add(zeroArray);
 
-                        JsonObject pathCoordPoint = new JsonObject();
-                        pathCoordPoint.addProperty("0", point.getX() / imageData.getServer().getWidth() * 1000);
-                        pathCoordPoint.addProperty("1", point.getY() / imageData.getServer().getWidth() * 1000);
-                        pathCoords.add(pathCoordPoint);
+                        pathCoords.add(segment);
                     }
 
                     JsonArray path = new JsonArray();

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -104,46 +104,59 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
         Collection<? extends PathObject> objects = PathObjectTools.getSupportedObjects(selectedObjects, supported);
 
         /**
-         * The JSON File imported by the annotation service has the following structure:
-         *  <JSON Array>                             (Array of annotations)
-         *   <JSON Object>                           (Annotation)
-         *       uid: <int>
-         *       name: <String>
-         *       <JSON Array> imgCoords              (Actual coordinates of annotation on image)
-         *           <JSON Object>                   (Point)
-         *               x: <Double>
-         *               y: <Double>
-         *               ...
-         *       <JSON Array> path                   (Describes information for painting the annotation in Paper.js)
-         *           0:Path
-         *           1:<JSON Object>                 (Path Information)
-         *               applyMatrix:<Boolean>
-         *               <JSON Array> segments       (These are the points used to paint the annotation)
-         *                   <JSON Object>           (Point)
-         *                       x: <Double>
-         *                       y: <Double>
-         *               closed:<Boolean>            (Whether the path is closed or not)
-         *               <JSON Array> fillColor
-         *                   0:<Double>              (red color)
-         *                   1:<Double>              (green color)
-         *                   2:<Double>              (blue color)
-         *                   3:<Double>              (alpha)
-         *               <JSON Array> strokeColor
-         *                   0:<Double>              (red color)
-         *                   1:<Double>              (green color)
-         *                   2:<Double>              (blue color)
-         *               strokeScaling:<Boolean>
-         *       zoom:<Double>                       (What zoom level the annotation was drawn at. Not important for us)
-         *       <JSON Array> context                (This array determines which annotations are within which other
-         *                                            annotations. Not important for now but may be needed as more
-         *                                            sophisticated paths need to be exported)
-         *       dictionary:<String>                 (Which dictionary these annotations belong to. For now we always
-         *                                            use "imported")
-         *   <JSON Object>                           (Annotation)
+         * The data-structure of the exported JSON:
+         * [
+         *   {
+         *     "SourceSlide": "name-of-file.svs"
+         *   },
+         *   {
+         *     "dictionaries": [
+         *       [
+         *         {
+         *           "uid": "some-uid",
+         *           "name": "some-name",
+         *           "imgCoords": [
+         *             {
+         *               "x": 0.0,
+         *               "y": 0.0
+         *             },
+         *             // ...
+         *           ],
+         *           // http://paperjs.org/reference/path/
+         *           "path": [
+         *             "Path",
+         *             {
+         *               "applyMatrix": true,
+         *               "data": {
+         *                 "id": "some-uid"
+         *               },
+         *               "segments": [
+         *                 // http://paperjs.org/reference/segment/#segment
+         *                 [
+         *                   [0.0, 0.0],
+         *                   [0.0, 0.0],
+         *                   [0.0, 0.0]
+         *                 ],
+         *                 // ...
+         *               ],
+         *               "closed": true,
+         *               "fillColor": [0.0, 0.0, 0.0, 0.0],
+         *               "strokeColor": [0.0, 0.0, 0.0],
+         *               "strokeWidth": 50
+         *             }
+         *           ],
+         *           "zoom": 0,
+         *           "context": [],
+         *           "dictionary": "default"
+         *         }
+         *       ]
+         *     ]
+         *   }
+         * ]
          */
-
         try {
-            JsonArray annotationLayout = new JsonArray();
+            JsonArray arrayToExport = new JsonArray();
+            JsonArray dictionariesArray = new JsonArray();
 
             int count = 0;
             for(PathObject annotation : objects) {
@@ -219,13 +232,21 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                     jsonAnnotation.add("context", context);
                     jsonAnnotation.addProperty("dictionary", "imported");
 
-                    annotationLayout.add(jsonAnnotation);
+                    dictionariesArray.add(jsonAnnotation);
                 }
+                JsonObject sourceSlide = new JsonObject();
+                sourceSlide.addProperty("SourceSlide", this.fileName + ".svs");
+                arrayToExport.add(sourceSlide);
+                JsonObject dictionaries = new JsonObject();
+                JsonArray arrayOfAnnotations = new JsonArray();
+                arrayOfAnnotations.add(dictionariesArray);
+                dictionaries.add("dictionaries", arrayOfAnnotations);
+                arrayToExport.add(dictionaries);
             }
 
             Gson gson = new GsonBuilder().create();
             Writer writer = new FileWriter(outputFile);
-            gson.toJson(annotationLayout,writer);
+            gson.toJson(arrayToExport,writer);
             writer.close();
         } catch(java.io.IOException ex){
             lastMessage = "Error Reading JSON File";

--- a/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
@@ -124,17 +124,22 @@ public class ImportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                     int blueChannel = Math.round(annotationColor.get(2).getAsFloat() * 255);
                     int annotationColorInt = ((((redChannel << 8) + greenChannel) << 8) + blueChannel);
 
-                    JsonArray coordinates = jsonAnnotation.getAsJsonObject().get("imgCoords").getAsJsonArray();
-                    float[] xPoints = new float[coordinates.size()];
-                    float[] yPoints = new float[coordinates.size()];
+                    JsonArray segments = jsonAnnotation.getAsJsonObject()
+                        .get("path").getAsJsonArray()
+                        .get(1).getAsJsonObject()
+                        .get("segments").getAsJsonArray();
+                    float[] xPoints = new float[segments.size()];
+                    float[] yPoints = new float[segments.size()];
 
                     //Loop over all coordinates in annotation
                     int numOfPoints = 0;
                     //Loop through all the coordinates
-                    for (JsonElement coordinate : coordinates) {
-                        xPoints[numOfPoints] = coordinate.getAsJsonObject().get("x").getAsFloat();
-                        yPoints[numOfPoints] = coordinate.getAsJsonObject().get("y").getAsFloat();
-
+                    for (JsonElement segment : segments) {
+                        JsonArray coordinates = segment.getAsJsonArray().get(0).getAsJsonArray();
+                        // The 0th element of the array is the X coordinate
+                        xPoints[numOfPoints] = coordinates.get(0).getAsFloat();
+                        // The 1st element of the array is the Y coordinate
+                        yPoints[numOfPoints] = coordinates.get(1).getAsFloat();
                         numOfPoints++;
                     }
 

--- a/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
@@ -181,6 +181,10 @@ public class ImportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                     annotationDictionary = annotationDictionary.substring(0, 1).toUpperCase() + annotationDictionary.substring(1);
                     annotationName = annotationName.substring(0, 1).toUpperCase() + annotationName.substring(1);
 
+                    /**
+                     * @todo Check if this if/else block is still necessary? `setColorRGB()` in the `if` statement
+                     * seems to never get called, hence being added after this if/else block.
+                     */
                     if (!PathClassFactory.pathClassExists(annotationName))
                         importedAnnotation.setColorRGB(annotationColorInt);
                     else {
@@ -188,6 +192,7 @@ public class ImportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                     }
 
                     importedAnnotation.setName(annotationSlideName + "-" + annotationDictionary + "-" + annotationUID);
+                    importedAnnotation.setColorRGB(annotationColorInt);
                     hierarchy.addPathObject(importedAnnotation, true, false);
                 }
 

--- a/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
@@ -191,7 +191,7 @@ public class ImportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                         importedAnnotation.setPathClass(PathClassFactory.getPathClass(annotationName));
                     }
 
-                    importedAnnotation.setName(annotationSlideName + "-" + annotationDictionary + "-" + annotationUID);
+                    importedAnnotation.setName(annotationUID);
                     importedAnnotation.setColorRGB(annotationColorInt);
                     hierarchy.addPathObject(importedAnnotation, true, false);
                 }


### PR DESCRIPTION
## Preamble

This PR makes two main changes:

1. Deprecating the `imgCoords` key, since the data stored in `imgCoords` is redundant data that can be found in `path.segments`

2. Refactoring the `ExportAnnotationServiceJSONPlugin` class to have an equivalent data structure of the `.json` files that are imported

## Screenshots

Exported annotations from `QuPath` to the internal annotation app are correctly mapped, but still needs work.

### Annotations Rendered In QuPath

![image](https://user-images.githubusercontent.com/16601729/70261187-c5afbe00-1746-11ea-94e2-e4ee2a7aaca4.png)

### Exported Annotations Rendered In Internal App

![image](https://user-images.githubusercontent.com/16601729/70261530-79b14900-1747-11ea-85fd-3d66500b1a3d.png)

Note that the coordinates are correct, but the metadata associated with each annotation is missing, including `fillColor` and `strokeColor` being incorrect.
