### PR TITLE
Bugfix/imported path object metadata

### DIFF
--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSON.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSON.java
@@ -48,7 +48,7 @@ public class ExportAnnotationServiceJSON implements PathCommand{
          * contain the slide name.
          */
         final String slideName = qupath.getViewer().getServer().getDisplayedImageName();
-        fileChooser.setInitialFileName(slideName + "_imported");
+        fileChooser.setInitialFileName(slideName + ".svs.annotations");
         File inputFile = fileChooser.showSaveDialog(null );
 
         if (inputFile == null) {

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -203,25 +203,23 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                     pathProperties.addProperty("closed", true);
                     JsonArray fillColour = new JsonArray();
 
-                    if (annotation.getPathClass() == null) {
-                        fillColour.add(1);
-                        fillColour.add(0);
-                        fillColour.add(0);
-                        fillColour.add(0.5);
-                    } else {
-                        int annotationRGB = annotation.getPathClass().getColor();
-                        fillColour.add((double) (ColorTools.red(annotationRGB)) / 255.0);
-                        fillColour.add((double) (ColorTools.green(annotationRGB)) / 255.0);
-                        fillColour.add((double) (ColorTools.blue(annotationRGB)) / 255.0);
-                        fillColour.add(0.5);
-                    }
+                    JsonArray strokeColor = new JsonArray();
+
+                    final int annotationRGB = annotation.getColorRGB();
+                    final double redValue = (double) (ColorTools.red(annotationRGB)) / 255.0;
+                    final double greenValue = (double) (ColorTools.green(annotationRGB)) / 255.0;
+                    final double blueValue = (double) (ColorTools.blue(annotationRGB)) / 255.0;
+                    fillColour.add(redValue);
+                    fillColour.add(greenValue);
+                    fillColour.add(blueValue);
+                    fillColour.add(0.5);
+                    strokeColor.add(redValue);
+                    strokeColor.add(greenValue);
+                    strokeColor.add(blueValue);
+
+                    pathProperties.add("strokeColor", strokeColor);
 
                     pathProperties.add("fillColor", fillColour);
-                    JsonArray strokeColor = new JsonArray();
-                    strokeColor.add(0);
-                    strokeColor.add(0);
-                    strokeColor.add(0);
-                    pathProperties.add("strokeColor", strokeColor);
                     pathProperties.addProperty("strokeScaling", false);
 
                     path.add(pathProperties);

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -205,7 +205,13 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
 
                     JsonArray strokeColor = new JsonArray();
 
-                    final int annotationRGB = annotation.getColorRGB();
+                    /**
+                     * PathObject.color is null by default, thus the color of the annotation needs to be manually set if
+                     * the user used the default color of RGB(255, 0, 0) (i.e. Red)
+                     */
+                    final int annotationRGB = annotation.getColorRGB() != null
+                        ? annotation.getColorRGB()
+                        : 16711680;
                     final double redValue = (double) (ColorTools.red(annotationRGB)) / 255.0;
                     final double greenValue = (double) (ColorTools.green(annotationRGB)) / 255.0;
                     final double blueValue = (double) (ColorTools.blue(annotationRGB)) / 255.0;

--- a/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
@@ -181,6 +181,10 @@ public class ImportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                     annotationDictionary = annotationDictionary.substring(0, 1).toUpperCase() + annotationDictionary.substring(1);
                     annotationName = annotationName.substring(0, 1).toUpperCase() + annotationName.substring(1);
 
+                    /**
+                     * @todo Check if this if/else block is still necessary? `setColorRGB()` in the `if` statement
+                     * seems to never get called, hence being added after this if/else block.
+                     */
                     if (!PathClassFactory.pathClassExists(annotationName))
                         importedAnnotation.setColorRGB(annotationColorInt);
                     else {
@@ -188,6 +192,7 @@ public class ImportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                     }
 
                     importedAnnotation.setName(annotationSlideName + "-" + annotationDictionary + "-" + annotationUID);
+                    importedAnnotation.setColorRGB(annotationColorInt);
                     hierarchy.addPathObject(importedAnnotation, true, false);
                 }
 

--- a/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
@@ -191,7 +191,7 @@ public class ImportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                         importedAnnotation.setPathClass(PathClassFactory.getPathClass(annotationName));
                     }
 
-                    importedAnnotation.setName(annotationSlideName + "-" + annotationDictionary + "-" + annotationUID);
+                    importedAnnotation.setName(annotationUID);
                     importedAnnotation.setColorRGB(annotationColorInt);
                     hierarchy.addPathObject(importedAnnotation, true, false);
                 }


### PR DESCRIPTION
## Preamble

Each annotation that gets imported has its metadata (i.e. colors, coordinates) populated in an instance of the `qupath.lib.objects.PathObject` class.

This PR ensures consistency between the data that is imported and exported, as prior to these changes, data that was imported was not being exported correctly (i.e. colors).