### PR TITLE
Bugfix/clean up json data structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,47 +12,39 @@ This extension is currently only compatible with [QuPath 0.1.2](https://github.c
 The coordinates, color, and other metadata of the annotations must be saved in a `.json` file, structured as follows:
 
 ```jsonc
-[
-  {
-    "SourceSlide": "name-of-file.svs"
-  },
-  {
-    "dictionaries": [
-      [
-        {
-          "uid": "some-uid",
-          "name": "some-name",
-          // http://paperjs.org/reference/path/
-          "path": [
-            "Path",
-            {
-              "applyMatrix": true,
-              "data": {
-                "id": "some-uid"
-              },
-              "segments": [
-                // http://paperjs.org/reference/segment/#segment
-                [
-                  [0.0, 0.0],
-                  [0.0, 0.0],
-                  [0.0, 0.0]
-                ],
-                // ...
-              ],
-              "closed": true,
-              "fillColor": [0.0, 0.0, 0.0, 0.0],
-              "strokeColor": [0.0, 0.0, 0.0],
-              "strokeWidth": 50
-            }
+{
+  "SourceSlide": "name-of-file.svs",
+  "dictionaries": [
+    {
+      "uid": "some-uid",
+      "name": "some-name",
+      // http://paperjs.org/reference/path/
+      "path": {
+          "applyMatrix": true,
+          "data": {
+            "id": "some-uid"
+          },
+          "segments": [
+            // http://paperjs.org/reference/segment/#segment
+            [
+              [0.0, 0.0],
+              [0.0, 0.0],
+              [0.0, 0.0]
+            ],
+            // ...
           ],
-          "zoom": 0,
-          "context": [],
-          "dictionary": "default"
-        }
-      ]
-    ]
-  }
-]
+          "closed": true,
+          "fillColor": [0.0, 0.0, 0.0, 0.0],
+          "strokeColor": [0.0, 0.0, 0.0],
+          "strokeWidth": 50,
+          "label": "Tumor" // (See `qupath.lib.objects.PathClass`)
+      }
+      "zoom": 0,
+      "context": [],
+      "dictionary": "default"
+    }
+  ]
+}
 ```
 
 A working example can be found below:
@@ -62,61 +54,54 @@ A working example can be found below:
 <p>
 
 ```jsonc
-[
-  {
-    "SourceSlide": "24496.svs"
-  },
-  {
-    "dictionaries": [
-      [
-        {
-          "uid": "dc466dd0-15f7-11ea-94f7-3541d0425afc",
-          "name": "dc466dd0-15f7-11ea-94f7-3541d0425afc",
-          // http://paperjs.org/reference/path/
-          "path": [
-            "Path",
-            {
-              "applyMatrix": true,
-              "data": {
-                "id": "dc466dd0-15f7-11ea-94f7-3541d0425afc"
-              },
-              "segments": [
-                // http://paperjs.org/reference/segment/#segment
-                [
-                  [4445.56952, 2904.39074],
-                  [0.9558, 6.05342],
-                  [-0.28748, -1.82071]
-                ],
-                [
-                  [4444.66043, 2909.84528],
-                  [1.02246, -1.53369],
-                  [-2.18812, 3.28217]
-                ],
-                [
-                  [4445.56952, 2921.66346],
-                  [-4.38693, -2.19347],
-                  [0.19696, 0.09848]
-                ],
-                [
-                  [4448.29679, 2922.57255],
-                  [0.00906, 0.09063],
-                  [-0.6098, -6.09799]
-                ]
+{
+  "SourceSlide": "24496.svs",
+  "dictionaries": [
+    [
+      {
+        "uid": "dc466dd0-15f7-11ea-94f7-3541d0425afc",
+        "name": "dc466dd0-15f7-11ea-94f7-3541d0425afc",
+        // http://paperjs.org/reference/path/
+        "path": {
+            "applyMatrix": true,
+            "data": {
+              "id": "dc466dd0-15f7-11ea-94f7-3541d0425afc"
+            },
+            "segments": [
+              // http://paperjs.org/reference/segment/#segment
+              [
+                [4445.56952, 2904.39074],
+                [0.9558, 6.05342],
+                [-0.28748, -1.82071]
               ],
-              "closed": true,
-              "fillColor": [0.81569, 0.41569, 0.41569, 0.5],
-              "strokeColor": [0.81569, 0.41569, 0.41569],
-              "strokeWidth": 50
-            }
-          ],
-          "zoom": 0,
-          "context": [],
-          "dictionary": "default"
-        }
-      ]
+              [
+                [4444.66043, 2909.84528],
+                [1.02246, -1.53369],
+                [-2.18812, 3.28217]
+              ],
+              [
+                [4445.56952, 2921.66346],
+                [-4.38693, -2.19347],
+                [0.19696, 0.09848]
+              ],
+              [
+                [4448.29679, 2922.57255],
+                [0.00906, 0.09063],
+                [-0.6098, -6.09799]
+              ]
+            ],
+            "closed": true,
+            "fillColor": [0.81569, 0.41569, 0.41569, 0.5],
+            "strokeColor": [0.81569, 0.41569, 0.41569],
+            "strokeWidth": 50
+        },
+        "zoom": 0,
+        "context": [],
+        "dictionary": "default"
+      }
     ]
-  }
-]
+  ]
+}
 ```
 
 </p>

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -112,9 +112,7 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
          *       "uid": "some-uid",
          *       "name": "some-name",
          *       // http://paperjs.org/reference/path/
-         *       "path": [
-         *         "Path",
-         *         {
+         *       "path": {
          *           "applyMatrix": true,
          *           "data": {
          *             "id": "some-uid"
@@ -132,8 +130,7 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
          *           "fillColor": [0.0, 0.0, 0.0, 0.0],
          *           "strokeColor": [0.0, 0.0, 0.0],
          *           "strokeWidth": 50
-         *         }
-         *       ],
+         *       }
          *       "zoom": 0,
          *       "context": [],
          *       "dictionary": "default"
@@ -182,8 +179,6 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                         pathCoords.add(segment);
                     }
 
-                    JsonArray path = new JsonArray();
-                    path.add("Path");
                     JsonObject pathProperties = new JsonObject();
                     pathProperties.addProperty("applyMatrix", true);
                     pathProperties.add("segments", pathCoords);
@@ -215,8 +210,7 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                     pathProperties.add("fillColor", fillColour);
                     pathProperties.addProperty("strokeScaling", false);
 
-                    path.add(pathProperties);
-                    jsonAnnotation.add("path", path);
+                    jsonAnnotation.add("path", pathProperties);
 
                     jsonAnnotation.addProperty("zoom", 1.0);
                     JsonArray context = new JsonArray();

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -129,7 +129,8 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
          *           "closed": true,
          *           "fillColor": [0.0, 0.0, 0.0, 0.0],
          *           "strokeColor": [0.0, 0.0, 0.0],
-         *           "strokeWidth": 50
+         *           "strokeWidth": 50,
+         *           "label": "Tumor" | "Stroma" | ... // (See `qupath.lib.objects.PathClass`)
          *       }
          *       "zoom": 0,
          *       "context": [],
@@ -216,6 +217,10 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                     JsonArray context = new JsonArray();
                     jsonAnnotation.add("context", context);
                     jsonAnnotation.addProperty("dictionary", "imported");
+                    String annotationPathClassName = annotation.getPathClass() != null
+                        ? annotation.getPathClass().getName()
+                        : "Tumor";
+                    jsonAnnotation.addProperty("label", annotationPathClassName);
 
                     dictionariesArray.add(jsonAnnotation);
                 }

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -152,7 +152,7 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                     count++;
                     JsonObject jsonAnnotation = new JsonObject();
                     jsonAnnotation.addProperty("uid", Integer.toString(count));
-                    jsonAnnotation.addProperty("name", (annotation.getPathClass() == null) ? "Unclassified" : annotation.getPathClass().toString());
+                    jsonAnnotation.addProperty("name", Integer.toString(count));
 
                     JsonArray pathCoords = new JsonArray();
 

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -235,9 +235,7 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                 sourceSlide.addProperty("SourceSlide", this.fileName + ".svs");
                 arrayToExport.add(sourceSlide);
                 JsonObject dictionaries = new JsonObject();
-                JsonArray arrayOfAnnotations = new JsonArray();
-                arrayOfAnnotations.add(dictionariesArray);
-                dictionaries.add("dictionaries", arrayOfAnnotations);
+                dictionaries.add("dictionaries", dictionariesArray);
                 arrayToExport.add(dictionaries);
             }
 

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -151,7 +151,7 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                 for(int i = 0; i<annotationPolygons[1].length; i++) {
                     count++;
                     JsonObject jsonAnnotation = new JsonObject();
-                    jsonAnnotation.addProperty("uid", count);
+                    jsonAnnotation.addProperty("uid", Integer.toString(count));
                     jsonAnnotation.addProperty("name", (annotation.getPathClass() == null) ? "Unclassified" : annotation.getPathClass().toString());
 
                     JsonArray pathCoords = new JsonArray();

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -105,47 +105,41 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
 
         /**
          * The data-structure of the exported JSON:
-         * [
-         *   {
-         *     "SourceSlide": "name-of-file.svs"
-         *   },
-         *   {
-         *     "dictionaries": [
-         *       [
+         * {
+         *   "SourceSlide": "name-of-file.svs"
+         *   "dictionaries": [
+         *     {
+         *       "uid": "some-uid",
+         *       "name": "some-name",
+         *       // http://paperjs.org/reference/path/
+         *       "path": [
+         *         "Path",
          *         {
-         *           "uid": "some-uid",
-         *           "name": "some-name",
-         *           // http://paperjs.org/reference/path/
-         *           "path": [
-         *             "Path",
-         *             {
-         *               "applyMatrix": true,
-         *               "data": {
-         *                 "id": "some-uid"
-         *               },
-         *               "segments": [
-         *                 // http://paperjs.org/reference/segment/#segment
-         *                 [
-         *                   [0.0, 0.0],
-         *                   [0.0, 0.0],
-         *                   [0.0, 0.0]
-         *                 ],
-         *                 // ...
-         *               ],
-         *               "closed": true,
-         *               "fillColor": [0.0, 0.0, 0.0, 0.0],
-         *               "strokeColor": [0.0, 0.0, 0.0],
-         *               "strokeWidth": 50
-         *             }
+         *           "applyMatrix": true,
+         *           "data": {
+         *             "id": "some-uid"
+         *           },
+         *           "segments": [
+         *             // http://paperjs.org/reference/segment/#segment
+         *             [
+         *               [0.0, 0.0],
+         *               [0.0, 0.0],
+         *               [0.0, 0.0]
+         *             ],
+         *             // ...
          *           ],
-         *           "zoom": 0,
-         *           "context": [],
-         *           "dictionary": "default"
+         *           "closed": true,
+         *           "fillColor": [0.0, 0.0, 0.0, 0.0],
+         *           "strokeColor": [0.0, 0.0, 0.0],
+         *           "strokeWidth": 50
          *         }
-         *       ]
-         *     ]
-         *   }
-         * ]
+         *       ],
+         *       "zoom": 0,
+         *       "context": [],
+         *       "dictionary": "default"
+         *     }
+         *   ]
+         * }
          */
         try {
             JsonObject objectToExport = new JsonObject();

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -148,7 +148,7 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
          * ]
          */
         try {
-            JsonArray arrayToExport = new JsonArray();
+            JsonObject objectToExport = new JsonObject();
             JsonArray dictionariesArray = new JsonArray();
 
             int count = 0;
@@ -231,17 +231,13 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
 
                     dictionariesArray.add(jsonAnnotation);
                 }
-                JsonObject sourceSlide = new JsonObject();
-                sourceSlide.addProperty("SourceSlide", this.fileName + ".svs");
-                arrayToExport.add(sourceSlide);
-                JsonObject dictionaries = new JsonObject();
-                dictionaries.add("dictionaries", dictionariesArray);
-                arrayToExport.add(dictionaries);
+                objectToExport.addProperty("SourceSlide", this.fileName + ".svs");
+                objectToExport.add("dictionaries", dictionariesArray);
             }
 
             Gson gson = new GsonBuilder().create();
             Writer writer = new FileWriter(outputFile);
-            gson.toJson(arrayToExport,writer);
+            gson.toJson(objectToExport,writer);
             writer.close();
         } catch(java.io.IOException ex){
             lastMessage = "Error Reading JSON File";

--- a/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
@@ -100,7 +100,7 @@ public class ImportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
 
                 // Dictionaries are created in the Annotation Service JS library. There isn't a clear convention on what they should mean but we will
                 // add a parameter to their imported objects so that they can be used later
-                String annotationDictionary = jsonAnnotation.getAsJsonObject().get("dictionary").getAsString();
+                String annotationLabel = jsonAnnotation.getAsJsonObject().get("label").getAsString();
 
                 // Dictionaries are created in the Annotation Service JS library. There isn't a clear convention on what they should mean but we will
                 // add a parameter to their imported objects so that they can be used later
@@ -167,18 +167,9 @@ public class ImportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                         importedAnnotation = new PathAnnotationObject(annotaionPoly);
                         break;
                 }
-                // Set first letter uppercase to match QuPath (In case they aren't already)
-                annotationDictionary = annotationDictionary.substring(0, 1).toUpperCase() + annotationDictionary.substring(1);
-                annotationName = annotationName.substring(0, 1).toUpperCase() + annotationName.substring(1);
 
-                /**
-                 * @todo Check if this if/else block is still necessary? `setColorRGB()` in the `if` statement
-                 * seems to never get called, hence being added after this if/else block.
-                 */
-                if (!PathClassFactory.pathClassExists(annotationName))
-                    importedAnnotation.setColorRGB(annotationColorInt);
-                else {
-                    importedAnnotation.setPathClass(PathClassFactory.getPathClass(annotationName));
+                if (PathClassFactory.pathClassExists(annotationLabel)) {
+                    importedAnnotation.setPathClass(PathClassFactory.getPathClass(annotationLabel));
                 }
 
                 importedAnnotation.setName(annotationUID);

--- a/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
@@ -91,9 +91,6 @@ public class ImportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
             JsonArray jsonAnnotationData = jsonParser.parse(jsonReader)
                     .getAsJsonArray();
 
-            String annotationSlideName = jsonAnnotationData.get(0)
-                    .getAsJsonObject().get("SourceSlide").getAsString();
-
             JsonArray jsonAnnotationDictionaries = jsonAnnotationData.get(1)
                     .getAsJsonObject().get("dictionaries")
                     .getAsJsonArray();

--- a/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
@@ -115,7 +115,6 @@ public class ImportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                     String annotationUID = jsonAnnotation.getAsJsonObject().get("uid").getAsString();
 
                     JsonArray annotationColor = jsonAnnotation.getAsJsonObject().get("path")
-                        .getAsJsonArray().get(1)
                         .getAsJsonObject().get("fillColor")
                         .getAsJsonArray();
 
@@ -125,8 +124,7 @@ public class ImportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
                     int annotationColorInt = ((((redChannel << 8) + greenChannel) << 8) + blueChannel);
 
                     JsonArray segments = jsonAnnotation.getAsJsonObject()
-                        .get("path").getAsJsonArray()
-                        .get(1).getAsJsonObject()
+                        .get("path").getAsJsonObject()
                         .get("segments").getAsJsonArray();
                     float[] xPoints = new float[segments.size()];
                     float[] yPoints = new float[segments.size()];

--- a/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ImportAnnotationServiceJSONPlugin.java
@@ -2,6 +2,7 @@ package qupath.AnnotationExchangeExtension;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.stream.JsonReader;
 import qupath.lib.images.ImageData;
@@ -88,111 +89,104 @@ public class ImportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
             JsonReader jsonReader = new JsonReader(new FileReader(inputFile));
             JsonParser jsonParser = new JsonParser();
 
-            JsonArray jsonAnnotationData = jsonParser.parse(jsonReader)
+            JsonObject jsonAnnotationData = jsonParser.parse(jsonReader).getAsJsonObject();
+
+            JsonArray jsonAnnotations = jsonAnnotationData.get("dictionaries").getAsJsonArray();
+
+            //Loop through every annotation in the dictionary
+            for (JsonElement jsonAnnotation : jsonAnnotations) {
+                //At the moment we were assuming that the name corresponds to tissue type so we will try to match it up with QuPath types and if none match, create a new one
+                String annotationName = jsonAnnotation.getAsJsonObject().get("name").getAsString();
+
+                // Dictionaries are created in the Annotation Service JS library. There isn't a clear convention on what they should mean but we will
+                // add a parameter to their imported objects so that they can be used later
+                String annotationDictionary = jsonAnnotation.getAsJsonObject().get("dictionary").getAsString();
+
+                // Dictionaries are created in the Annotation Service JS library. There isn't a clear convention on what they should mean but we will
+                // add a parameter to their imported objects so that they can be used later
+                String annotationUID = jsonAnnotation.getAsJsonObject().get("uid").getAsString();
+
+                JsonArray annotationColor = jsonAnnotation.getAsJsonObject().get("path")
+                    .getAsJsonObject().get("fillColor")
                     .getAsJsonArray();
 
-            JsonArray jsonAnnotationDictionaries = jsonAnnotationData.get(1)
-                    .getAsJsonObject().get("dictionaries")
-                    .getAsJsonArray();
+                int redChannel = Math.round(annotationColor.get(0).getAsFloat() * 255);
+                int greenChannel = Math.round(annotationColor.get(1).getAsFloat() * 255);
+                int blueChannel = Math.round(annotationColor.get(2).getAsFloat() * 255);
+                int annotationColorInt = ((((redChannel << 8) + greenChannel) << 8) + blueChannel);
 
-            //Loop though all the "dictionaries"
-            for (JsonElement jsonAnnotationDictionary : jsonAnnotationDictionaries) {
-                JsonArray jsonAnnotations = jsonAnnotationDictionary.getAsJsonArray();
-                //Loop through every annotation in the dictionary
-                for (JsonElement jsonAnnotation : jsonAnnotations) {
-                    //At the moment we were assuming that the name corresponds to tissue type so we will try to match it up with QuPath types and if none match, create a new one
-                    String annotationName = jsonAnnotation.getAsJsonObject().get("name").getAsString();
+                JsonArray segments = jsonAnnotation.getAsJsonObject()
+                    .get("path").getAsJsonObject()
+                    .get("segments").getAsJsonArray();
+                float[] xPoints = new float[segments.size()];
+                float[] yPoints = new float[segments.size()];
 
-                    // Dictionaries are created in the Annotation Service JS library. There isn't a clear convention on what they should mean but we will
-                    // add a parameter to their imported objects so that they can be used later
-                    String annotationDictionary = jsonAnnotation.getAsJsonObject().get("dictionary").getAsString();
-
-                    // Dictionaries are created in the Annotation Service JS library. There isn't a clear convention on what they should mean but we will
-                    // add a parameter to their imported objects so that they can be used later
-                    String annotationUID = jsonAnnotation.getAsJsonObject().get("uid").getAsString();
-
-                    JsonArray annotationColor = jsonAnnotation.getAsJsonObject().get("path")
-                        .getAsJsonObject().get("fillColor")
-                        .getAsJsonArray();
-
-                    int redChannel = Math.round(annotationColor.get(0).getAsFloat() * 255);
-                    int greenChannel = Math.round(annotationColor.get(1).getAsFloat() * 255);
-                    int blueChannel = Math.round(annotationColor.get(2).getAsFloat() * 255);
-                    int annotationColorInt = ((((redChannel << 8) + greenChannel) << 8) + blueChannel);
-
-                    JsonArray segments = jsonAnnotation.getAsJsonObject()
-                        .get("path").getAsJsonObject()
-                        .get("segments").getAsJsonArray();
-                    float[] xPoints = new float[segments.size()];
-                    float[] yPoints = new float[segments.size()];
-
-                    //Loop over all coordinates in annotation
-                    int numOfPoints = 0;
-                    //Loop through all the coordinates
-                    for (JsonElement segment : segments) {
-                        JsonArray coordinates = segment.getAsJsonArray().get(0).getAsJsonArray();
-                        // The 0th element of the array is the X coordinate
-                        xPoints[numOfPoints] = coordinates.get(0).getAsFloat();
-                        // The 1st element of the array is the Y coordinate
-                        yPoints[numOfPoints] = coordinates.get(1).getAsFloat();
-                        numOfPoints++;
-                    }
-
-                    PathAnnotationObject importedAnnotation;
-
-                    // Import the annotation as a Point/Line/Polygon depending on number of coordinates / size
-                    switch(numOfPoints) {
-                        case 1:
-                            // Only a single point was found, thus this is a point annotation
-                            PointsROI annotaionPoint = new PointsROI(xPoints[0], yPoints[0]);
-                            importedAnnotation = new PathAnnotationObject(annotaionPoint);
-                            break;
-                        case 2:
-                            // Two points were found, thus this is a line annotation
-                            LineROI annotationLine = new LineROI(xPoints[0],yPoints[0],xPoints[1],yPoints[1]);
-                            /**
-                             * If the line is really short then we will assume it's a point which was made into a line
-                             * by mistake
-                             */
-                            if (
-                                annotationLine.getScaledLength(
-                                    imageData.getServer().getPixelWidthMicrons(),
-                                    imageData.getServer().getPixelWidthMicrons()
-                                ) < 5
-                            ) {
-                                PointsROI annotationPointCentroid = new PointsROI(annotationLine.getCentroidX(),annotationLine.getCentroidY());
-                                importedAnnotation = new PathAnnotationObject(annotationPointCentroid);
-                            } else {
-                                importedAnnotation = new PathAnnotationObject(annotationLine);
-                            }
-                            break;
-                        default:
-                            // Multiple points were found, thus this is a polygon annotation
-                            PolygonROI annotaionPoly = new PolygonROI(xPoints, yPoints, -1, 0, 0);
-                            importedAnnotation = new PathAnnotationObject(annotaionPoly);
-                            break;
-                    }
-                    // Set first letter uppercase to match QuPath (In case they aren't already)
-                    annotationDictionary = annotationDictionary.substring(0, 1).toUpperCase() + annotationDictionary.substring(1);
-                    annotationName = annotationName.substring(0, 1).toUpperCase() + annotationName.substring(1);
-
-                    /**
-                     * @todo Check if this if/else block is still necessary? `setColorRGB()` in the `if` statement
-                     * seems to never get called, hence being added after this if/else block.
-                     */
-                    if (!PathClassFactory.pathClassExists(annotationName))
-                        importedAnnotation.setColorRGB(annotationColorInt);
-                    else {
-                        importedAnnotation.setPathClass(PathClassFactory.getPathClass(annotationName));
-                    }
-
-                    importedAnnotation.setName(annotationUID);
-                    importedAnnotation.setColorRGB(annotationColorInt);
-                    hierarchy.addPathObject(importedAnnotation, true, false);
+                //Loop over all coordinates in annotation
+                int numOfPoints = 0;
+                //Loop through all the coordinates
+                for (JsonElement segment : segments) {
+                    JsonArray coordinates = segment.getAsJsonArray().get(0).getAsJsonArray();
+                    // The 0th element of the array is the X coordinate
+                    xPoints[numOfPoints] = coordinates.get(0).getAsFloat();
+                    // The 1st element of the array is the Y coordinate
+                    yPoints[numOfPoints] = coordinates.get(1).getAsFloat();
+                    numOfPoints++;
                 }
 
-                hierarchy.fireHierarchyChangedEvent(this);
+                PathAnnotationObject importedAnnotation;
+
+                // Import the annotation as a Point/Line/Polygon depending on number of coordinates / size
+                switch(numOfPoints) {
+                    case 1:
+                        // Only a single point was found, thus this is a point annotation
+                        PointsROI annotaionPoint = new PointsROI(xPoints[0], yPoints[0]);
+                        importedAnnotation = new PathAnnotationObject(annotaionPoint);
+                        break;
+                    case 2:
+                        // Two points were found, thus this is a line annotation
+                        LineROI annotationLine = new LineROI(xPoints[0],yPoints[0],xPoints[1],yPoints[1]);
+                        /**
+                         * If the line is really short then we will assume it's a point which was made into a line
+                         * by mistake
+                         */
+                        if (
+                            annotationLine.getScaledLength(
+                                imageData.getServer().getPixelWidthMicrons(),
+                                imageData.getServer().getPixelWidthMicrons()
+                            ) < 5
+                        ) {
+                            PointsROI annotationPointCentroid = new PointsROI(annotationLine.getCentroidX(),annotationLine.getCentroidY());
+                            importedAnnotation = new PathAnnotationObject(annotationPointCentroid);
+                        } else {
+                            importedAnnotation = new PathAnnotationObject(annotationLine);
+                        }
+                        break;
+                    default:
+                        // Multiple points were found, thus this is a polygon annotation
+                        PolygonROI annotaionPoly = new PolygonROI(xPoints, yPoints, -1, 0, 0);
+                        importedAnnotation = new PathAnnotationObject(annotaionPoly);
+                        break;
+                }
+                // Set first letter uppercase to match QuPath (In case they aren't already)
+                annotationDictionary = annotationDictionary.substring(0, 1).toUpperCase() + annotationDictionary.substring(1);
+                annotationName = annotationName.substring(0, 1).toUpperCase() + annotationName.substring(1);
+
+                /**
+                 * @todo Check if this if/else block is still necessary? `setColorRGB()` in the `if` statement
+                 * seems to never get called, hence being added after this if/else block.
+                 */
+                if (!PathClassFactory.pathClassExists(annotationName))
+                    importedAnnotation.setColorRGB(annotationColorInt);
+                else {
+                    importedAnnotation.setPathClass(PathClassFactory.getPathClass(annotationName));
+                }
+
+                importedAnnotation.setName(annotationUID);
+                importedAnnotation.setColorRGB(annotationColorInt);
+                hierarchy.addPathObject(importedAnnotation, true, false);
             }
+
+            hierarchy.fireHierarchyChangedEvent(this);
         } catch(java.io.FileNotFoundException ex){
             lastMessage = "Error Reading JSON File";
             return false;


### PR DESCRIPTION
## Preamble

This PR concerns complying with the data structure change made in the internal GSC annotation application.

Specifically, the JSON file containing annotations has had its data structure streamlined in the GSC annotation application, thus the changes here conform with those changes.

## Data-Structure Change Overview

### Before:

```jsonc
[
  {
    "SourceSlide": "CMP-02-01-Bx A-1-001.svs"
  },
  {
    "dictionaries": [ // An array with only ever a single element
      [
        {
          "uid": 1,
          "name": "Unclassified",
          "path": ["Path", {
            "applyMatrix": true,
            "segments": [
              [
                [13698.1298828125, 6462.8271484375],
                [0.0, 0.0],
                [0.0, 0.0]
              ],
              // ...
            ],
            "closed": true,
            "strokeColor": [1.0, 0.0, 0.0],
            "fillColor": [1.0, 0.0, 0.0, 0.5],
            "strokeScaling": false
          }],
          "zoom": 1.0,
          "context": [],
          "dictionary": "imported",
          "label": "Stroma"
        },
        {
          // ...
        },
      ],
    ],
  },
]
```

### After:

```jsonc
{
  "SourceSlide": "CMP-02-01-Bx A-1-001.svs"
  "dictionaries":[
    {
      "uid": 1,
      "name": "Unclassified",
      "path": {
        "applyMatrix": true,
        "segments": [
          [
            [13698.1298828125, 6462.8271484375],
            [0.0, 0.0],
            [0.0, 0.0]
          ],
          // ...
        ],
        "closed": true,
        "strokeColor": [1.0, 0.0, 0.0],
        "fillColor": [1.0, 0.0, 0.0, 0.5],
        "strokeScaling": false
      },
      "zoom": 1.0,
      "context": [],
      "dictionary": "imported",
      "label": "Stroma"
    },
    {
      // ...
    },
  ],
},

```