### PR TITLE
Export the name and uid of each annotation

### DIFF
--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -19,6 +19,7 @@ import java.io.FileWriter;
 import java.io.Writer;
 import java.util.*;
 import java.util.List;
+import java.util.UUID;
 
 public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedImage> {
 
@@ -150,8 +151,15 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
 
                 for(int i = 0; i<annotationPolygons[1].length; i++) {
                     JsonObject jsonAnnotation = new JsonObject();
-                    jsonAnnotation.addProperty("uid", annotation.getName());
-                    jsonAnnotation.addProperty("name", annotation.getName());
+
+                    final String uid = UUID.randomUUID().toString();
+
+                    final String name = annotation.getName() != null
+                      ? annotation.getName()
+                      : uid;
+
+                    jsonAnnotation.addProperty("uid", uid);
+                    jsonAnnotation.addProperty("name", name);
 
                     JsonArray pathCoords = new JsonArray();
 

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -143,17 +143,15 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
             JsonObject objectToExport = new JsonObject();
             JsonArray dictionariesArray = new JsonArray();
 
-            int count = 0;
             for(PathObject annotation : objects) {
                 PathShape pathShape = (PathShape)annotation.getROI();
                 Area area = PathROIToolsAwt.getArea(pathShape);
                 PolygonROI[][] annotationPolygons = PathROIToolsAwt.splitAreaToPolygons(area);
 
                 for(int i = 0; i<annotationPolygons[1].length; i++) {
-                    count++;
                     JsonObject jsonAnnotation = new JsonObject();
-                    jsonAnnotation.addProperty("uid", Integer.toString(count));
-                    jsonAnnotation.addProperty("name", Integer.toString(count));
+                    jsonAnnotation.addProperty("uid", annotation.getName());
+                    jsonAnnotation.addProperty("name", annotation.getName());
 
                     JsonArray pathCoords = new JsonArray();
 


### PR DESCRIPTION
## Preamble

This PR fixes `uid` and `name` of each exported annotation being assigned an arbitrary incremented integer.

## Commit History

* Export the name and uid of each annotation

  Rather than assigning the `uid` and `name` an arbitrarily incremented
  `count` value, use `getName()` to retrieve the name assigned to each
  annotation, and assign this value to the exported `uid` and `name`
  attributes