### PR TITLE
Remove un-used attributes from exported JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ The coordinates, color, and other metadata of the annotations must be saved in a
           "strokeWidth": 50,
           "label": "Tumor" // (See `qupath.lib.objects.PathClass`)
       }
-      "zoom": 0,
-      "context": [],
-      "dictionary": "default"
     }
   ]
 }
@@ -94,10 +91,7 @@ A working example can be found below:
             "fillColor": [0.81569, 0.41569, 0.41569, 0.5],
             "strokeColor": [0.81569, 0.41569, 0.41569],
             "strokeWidth": 50
-        },
-        "zoom": 0,
-        "context": [],
-        "dictionary": "default"
+        }
       }
     ]
   ]

--- a/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
+++ b/src/main/java/qupath/AnnotationExchangeExtension/ExportAnnotationServiceJSONPlugin.java
@@ -132,9 +132,6 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
          *           "strokeWidth": 50,
          *           "label": "Tumor" | "Stroma" | ... // (See `qupath.lib.objects.PathClass`)
          *       }
-         *       "zoom": 0,
-         *       "context": [],
-         *       "dictionary": "default"
          *     }
          *   ]
          * }
@@ -213,10 +210,6 @@ public class ExportAnnotationServiceJSONPlugin extends AbstractPlugin<BufferedIm
 
                     jsonAnnotation.add("path", pathProperties);
 
-                    jsonAnnotation.addProperty("zoom", 1.0);
-                    JsonArray context = new JsonArray();
-                    jsonAnnotation.add("context", context);
-                    jsonAnnotation.addProperty("dictionary", "imported");
                     String annotationPathClassName = annotation.getPathClass() != null
                         ? annotation.getPathClass().getName()
                         : "Tumor";


### PR DESCRIPTION
## Preamble

This PR removes un-used attributes from the exported `.json` file storing the coordinates of each annotation.

Since the values were not used for any purpose in `QuPath`, they were not imported, thus no lines of code needed to be changed in the `ImportAnnotationServiceJSON.java` or `ImportAnnotationServiceJSONPlugin.java` files.

## Commit History

* Remove un-used attributes from exported JSON file

  The `zoom`, `context` and `dictionary` attributes were holdover
  attributes from when the project was inherited from previous developers

  The values they provide are not used in any way in `QuPath`, nor the
  internal GSC annotation application, and as such, can be removed from
  the `.json` file storing annotations